### PR TITLE
Additional query methods, removed passing of unset fields, allow extra values

### DIFF
--- a/src/shopware_api_client/client.py
+++ b/src/shopware_api_client/client.py
@@ -49,7 +49,7 @@ class AdminClient(ClientBase):
 
         for obj in objs:
             if isinstance(obj, ApiModelBase):
-                obj_list.append(obj.model_dump(by_alias=True, mode="json"))
+                obj_list.append(obj.model_dump(by_alias=True, mode="json", exclude_unset=True))
             else:
                 obj_list.append(obj)
 
@@ -67,7 +67,7 @@ class AdminClient(ClientBase):
 
         for obj in objs:
             if isinstance(obj, ApiModelBase):
-                obj_list.append(obj.model_dump(by_alias=True, mode="json"))
+                obj_list.append(obj.model_dump(by_alias=True, mode="json", exclude_unset=True))
             else:
                 obj_list.append(obj)
 

--- a/src/shopware_api_client/endpoints/relations.py
+++ b/src/shopware_api_client/endpoints/relations.py
@@ -1,6 +1,7 @@
 from typing import Any, Coroutine, Generic
 
 from ..base import ApiModelBase, EndpointBase, ModelClass
+from ..exceptions import SWNoClientProvided
 
 
 class ForeignRelation(Generic[ModelClass]):
@@ -32,8 +33,19 @@ class ManyRelation(Generic[ModelClass]):
         self.model = model
         self.api_link = api_link
 
-    def __get__(self, instance: Any, owner: type[Any]) -> Coroutine[Any, Any, list[ModelClass] | list[dict[str, Any]]]:
+    async def fake_async(self, value: Any) -> Any:
+        return value
+
+    def __get__(
+        self, instance: Any, owner: type[Any]
+    ) -> Coroutine[Any, Any, list[ModelClass] | list[dict[str, Any]] | None]:
         from ..client import registry
 
         model_class: type[ApiModelBase[EndpointBase]] = registry.get_admin_model(self.model)  # type: ignore
-        return model_class.using(instance._get_client()).get_related(instance, relation=self.api_link)
+        try:
+            return model_class.using(instance._get_client()).get_related(instance, relation=self.api_link)
+        except SWNoClientProvided:
+            return self.fake_async(None)
+
+    def __set__(self, instance: Any, value: list[ModelClass]) -> None:
+        setattr(instance, self.api_link, value)


### PR DESCRIPTION
- add support for .select_related(association={})
- add support for .only(entity=["field", "field2"])
- switch Admin API Format to application/json
- allow extra values passed to ApiModelBase via constructor (to allow for setting association data)
- exclude unset model attributes when sending to shopware (to allow for partial updates)
