### PR TITLE
fixed that relations can be omitted, save-Parameter "force_insert" added

### DIFF
--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -179,10 +179,10 @@ class ApiModelBase(BaseModel, Generic[EndpointClass]):
         endpoint: EndpointClass = getattr(self._get_client(), self._identifier).__class__(self._get_client())  # type: ignore
         return endpoint
 
-    async def save(self) -> Self | dict:
+    async def save(self, force_insert: bool = False) -> Self | dict:
         endpoint = self._get_endpoint()
 
-        if self.id is None:
+        if force_insert or self.id is None:
             result = await endpoint.create(obj=self)
         else:
             result = await endpoint.update(pk=self.id, obj=self)

--- a/src/shopware_api_client/endpoints/admin/core/rule.py
+++ b/src/shopware_api_client/endpoints/admin/core/rule.py
@@ -51,6 +51,6 @@ from .payment_method import PaymentMethod  # noqa: E402
 from .product_price import ProductPrice  # noqa: E402
 from .promotion import Promotion  # noqa: E402
 from .promotion_discount import PromotionDiscount  # noqa: E402
+from .rule_condition import RuleCondition  # noqa: E402
 from .shipping_method import ShippingMethod  # noqa: E402
 from .tag import Tag  # noqa: E402
-from .rule_condition import RuleCondition  # noqa: E402

--- a/src/shopware_api_client/endpoints/relations.py
+++ b/src/shopware_api_client/endpoints/relations.py
@@ -15,6 +15,7 @@ class ForeignRelation(Generic[ModelClass]):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        assert handler.field_name is not None
         data_tp = get_args(source)[0]
         data_schema = handler.generate_schema(data_tp)
 
@@ -77,6 +78,7 @@ class ManyRelation(Generic[ModelClass]):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        assert handler.field_name is not None
         data_tp = get_args(source)[0]
         data_schema = handler.generate_schema(data_tp)
 

--- a/src/shopware_api_client/endpoints/relations.py
+++ b/src/shopware_api_client/endpoints/relations.py
@@ -18,13 +18,16 @@ class ForeignRelation(Generic[ModelClass]):
         data_tp = get_args(source)[0]
         data_schema = handler.generate_schema(data_tp)
 
-        return core_schema.with_info_after_validator_function(
-            cls._validate,
-            core_schema.nullable_schema(data_schema),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                cls._serialize, info_arg=False, return_schema=core_schema.nullable_schema(data_schema)
+        return core_schema.with_default_schema(
+            core_schema.with_info_after_validator_function(
+                cls._validate,
+                core_schema.nullable_schema(data_schema),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    cls._serialize, info_arg=False, return_schema=core_schema.nullable_schema(data_schema)
+                ),
+                field_name=handler.field_name,
             ),
-            field_name=handler.field_name,
+            default=ForeignRelation(field_name=handler.field_name, data=None),
         )
 
     @staticmethod
@@ -77,15 +80,18 @@ class ManyRelation(Generic[ModelClass]):
         data_tp = get_args(source)[0]
         data_schema = handler.generate_schema(data_tp)
 
-        return core_schema.with_info_after_validator_function(
-            cls._validate,
-            core_schema.nullable_schema(core_schema.list_schema(data_schema)),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                cls._serialize,
-                info_arg=False,
-                return_schema=core_schema.nullable_schema(core_schema.list_schema(data_schema)),
+        return core_schema.with_default_schema(
+            core_schema.with_info_after_validator_function(
+                cls._validate,
+                core_schema.nullable_schema(core_schema.list_schema(data_schema)),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    cls._serialize,
+                    info_arg=False,
+                    return_schema=core_schema.nullable_schema(core_schema.list_schema(data_schema)),
+                ),
+                field_name=handler.field_name,
             ),
-            field_name=handler.field_name,
+            default=ManyRelation(field_name=handler.field_name, data=[]),
         )
 
     @staticmethod


### PR DESCRIPTION
- ManyRelations and ForeignRelations may be omitted when creating Instances
Added:
 - New parameter for save(): force_insert=False - force creation of new entry even with set id