### PR TITLE
new exceptions, retries and product fixes

### DIFF
--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import UTC, datetime
 from typing import Any, AsyncGenerator, Callable, Generic, Self, Type, TypeVar, get_origin, overload
@@ -7,7 +8,16 @@ from pydantic import AliasChoices, AliasGenerator, AwareDatetime, BaseModel, Con
 from pydantic.alias_generators import to_camel
 
 from .endpoints.base_fields import IdField
-from .exceptions import SWAPIError, SWAPIException, SWFilterException, SWNoClientProvided
+from .exceptions import (
+    SWAPIError,
+    SWAPIErrorList,
+    SWAPIException,
+    SWAPIGatewayTimeout,
+    SWAPIInternalServerError,
+    SWAPIServiceUnavailable,
+    SWFilterException,
+    SWNoClientProvided,
+)
 from .logging import logger
 
 EndpointClass = TypeVar("EndpointClass", bound="EndpointBase[Any]")
@@ -61,15 +71,42 @@ class ClientBase:
         headers = self._get_headers()
         headers.update(kwargs.pop("headers", {}))
 
-        response = await client.request(method, url, headers=headers, **kwargs)
+        retries = int(kwargs.pop("retries", 0))
+        retry_errors = tuple(
+            kwargs.pop("retry_errors", [SWAPIInternalServerError, SWAPIServiceUnavailable, SWAPIGatewayTimeout])
+        )
+        no_retry_errors = tuple(kwargs.pop("no_retry_errors", []))
 
-        if response.status_code >= 400:
-            try:
-                raise SWAPIError(response.json().get("errors"))
-            except json.JSONDecodeError:
-                raise SWAPIError(f"Status: {response.status_code}: {response.text}")
+        retry_count = 0
+        while True:
+            response = await client.request(method, url, headers=headers, **kwargs)
+            if response.status_code >= 400:
+                try:
+                    error: SWAPIError | SWAPIErrorList = SWAPIError.from_errors(response.json().get("errors"))
+                except json.JSONDecodeError:
+                    error: SWAPIError | SWAPIErrorList = SWAPIError.from_response(response)  # type: ignore
 
-        return response
+                if isinstance(error, SWAPIErrorList) and len(error.errors) == 1:
+                    error = error.errors[0]
+
+                if isinstance(error, SWAPIErrorList):
+                    if any([isinstance(err, no_retry_errors) for err in error.errors]):
+                        raise error
+
+                    if not any([isinstance(err, retry_errors) for err in error.errors]):
+                        raise error
+
+                elif isinstance(error, no_retry_errors) or not isinstance(error, retry_errors):
+                    raise error
+
+                if retry_count == retries:
+                    raise error
+
+                logger.debug(f"Try failed, retrying in {2 ** retry_count} seconds.")
+                await asyncio.sleep(2**retry_count)
+                retry_count += 1
+            else:
+                return response
 
     async def get(self, relative_url: str, **kwargs: Any) -> httpx.Response:
         return await self._make_request(method="GET", relative_url=relative_url, **kwargs)

--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -128,12 +128,12 @@ class ClientBase:
         await self._get_client().aclose()
 
     async def bulk_upsert(
-        self, name: str, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: dict[str, Any]
+        self, name: str, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: Any
     ) -> dict[str, Any] | None:
         raise SWAPIException("bulk_upsert is only supported in the admin API")
 
     async def bulk_delete(
-        self, name: str, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: dict[str, Any]
+        self, name: str, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: Any
     ) -> dict[str, Any]:
         raise SWAPIException("bulk_delete is only supported in the admin API")
 
@@ -495,13 +495,11 @@ class EndpointBase(Generic[ModelClass]):
         return self
 
     async def bulk_upsert(
-        self, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: dict[str, Any]
+        self, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: Any
     ) -> dict[str, Any] | None:
         return await self.client.bulk_upsert(self.name, objs, **request_kwargs)
 
-    async def bulk_delete(
-        self, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def bulk_delete(self, objs: list[ModelClass] | list[dict[str, Any]], **request_kwargs: Any) -> dict[str, Any]:
         return await self.client.bulk_delete(self.name, objs, **request_kwargs)
 
     def limit(self, count: int | None) -> "Self":

--- a/src/shopware_api_client/endpoints/admin/core/product.py
+++ b/src/shopware_api_client/endpoints/admin/core/product.py
@@ -70,7 +70,7 @@ class ProductBase(ApiModelBase[EndpointClass]):
     pack_unit_plural: str | None = None
     custom_fields: dict[str, Any] | None = None
     slot_config: dict[str, Any] | None = None
-    custom_search_keywords: list[dict[str, Any]] | None = None
+    custom_search_keywords: list[str] | None = None
     available_stock: int | None = None
     stock: int
     translated: dict[str, Any] | None = None

--- a/src/shopware_api_client/exceptions.py
+++ b/src/shopware_api_client/exceptions.py
@@ -1,3 +1,8 @@
+from typing import Any
+
+from httpx import Response
+
+
 class SWException(Exception):
     pass
 
@@ -23,8 +28,118 @@ class SWAPIMethodNotAvailable(SWAPIConfigException):
 
 
 class SWAPIError(SWAPIException):
-    pass
+    def __init__(self, **kwargs: Any) -> None:
+        self.id = kwargs.get("id", "")
+        self.links = kwargs.get("links", {})
+        self.status = kwargs.get("status", "")
+        self.code = kwargs.get("code", "")
+        self.title = kwargs.get("title", "")
+        self.detail = kwargs.get("detail", "")
+        self.description = kwargs.get("description", "")
+        self.source = kwargs.get("source", {})
+        self.meta = kwargs.get("meta", {})
+
+    def __str__(self) -> str:
+        return f"Status: {self.status} {self.title} - {self.detail}"
+
+    @classmethod
+    def get_exception_class(cls, status_code: int) -> type["SWAPIError"]:
+        match status_code:
+            case 400:
+                return SWAPIBadRequest
+            case 401:
+                return SWAPIUnauthorized
+            case 403:
+                return SWAPIForbidden
+            case 404:
+                return SWAPINotFound
+            case 405:
+                return SWAPIMethodNotAllowed
+            case 412:
+                return SWAPIPreconditionFailed
+            case 500:
+                return SWAPIInternalServerError
+            case 501:
+                return SWAPINotImplemented
+            case 502:
+                return SWAPIBadGateway
+            case 503:
+                return SWAPIServiceUnavailable
+            case 504:
+                return SWAPIGatewayTimeout
+            case 505:
+                return SWAPIHTTPVersionNotSupported
+            case _:
+                return SWAPIError
+
+    @classmethod
+    def from_errors(cls, errors: list[dict[str, Any]]) -> "SWAPIErrorList":
+        errlist = []
+
+        for error in errors:
+            exception_class = cls.get_exception_class(int(error["status"]))
+            errlist.append(exception_class(**error))
+
+        return SWAPIErrorList(errlist)
+
+    @classmethod
+    def from_response(cls, response: Response) -> "SWAPIError":
+        exception_class = cls.get_exception_class(response.status_code)
+        return exception_class(status=response.status_code, title=response.reason_phrase, detail=response.text)
+
+
+class SWAPIErrorList(SWAPIException):
+    def __init__(self, errors: list[SWAPIError]) -> None:
+        self.errors = errors
 
 
 class SWNoClientProvided(SWModelException):
+    pass
+
+
+class SWAPIBadRequest(SWAPIError):
+    pass
+
+
+class SWAPIUnauthorized(SWAPIError):
+    pass
+
+
+class SWAPIForbidden(SWAPIError):
+    pass
+
+
+class SWAPINotFound(SWAPIError):
+    pass
+
+
+class SWAPIMethodNotAllowed(SWAPIError):
+    pass
+
+
+class SWAPIPreconditionFailed(SWAPIError):
+    pass
+
+
+class SWAPIInternalServerError(SWAPIError):
+    pass
+
+
+class SWAPINotImplemented(SWAPIError):
+    pass
+
+
+class SWAPIBadGateway(SWAPIError):
+    pass
+
+
+class SWAPIServiceUnavailable(SWAPIError):
+    pass
+
+
+class SWAPIGatewayTimeout(SWAPIError):
+    pass
+
+
+class SWAPIHTTPVersionNotSupported(SWAPIError):
     pass


### PR DESCRIPTION
SWAPIError class has classmethods "from_errors" and "from_response" and outputs different SWAPIError Exception classes.

This can be used for retrying API Requests (new params: retries=3, retry_errors=[SWAPIInternalServerError, SWAPIServiceUnavailable, SWAPIGatewayTimeout], no_retry_errors=[])