### PR TITLE
Better handling of pydantic validation errors caused by invalid data from Shopware

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -594,6 +594,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-random-order"
 version = "1.1.1"
 description = "Randomise the order in which pytest tests are run with some control over the randomness"
@@ -958,4 +975,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e99f7481fc12f4e12bc46e7b0957ad3c209a6ae9106a03a6886c6a57d19fa8cd"
+content-hash = "a1efc5050212bc50952472bf2f893295d957c1fbd826e7204420105a07f617b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-cov = ">=4.1,<6.0"
 ruff = ">=0.5.0,<0.7"
 pytest-asyncio = ">=0.23.3,<0.25.0"
 pytest-recording = "^0.13.1"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,11 +46,12 @@ class TestAdminClient:
         client = AdminClient(config=self.admin_config)
         with pytest.raises(SWAPIDataValidationError) as exc_info:
             await client.cms_page.all()
-            assert len(exc_info.value.errors) == 3
-            assert len(caplog.records) == 3
-            assert caplog.records[0].id == 1
-            assert caplog.records[1].id is None
-            assert caplog.records[2].id == 3
+        
+        assert len(exc_info.value.errors) == 3
+        assert len(caplog.records) == 3
+        assert caplog.records[0].id == 1
+        assert caplog.records[1].id is None
+        assert caplog.records[2].id == 3
 
 
 class TestStoreClient:


### PR DESCRIPTION
This PR adds `pydantic.ValidationError` handling while receiving data from Shopware. 

Validation errors will be logged with additional tracing information to facilitate data correction and the finally raised as a `SWAPIDataValidationError`.