### PR TITLE
slotConfig field of product can be a list?!?

### DIFF
--- a/src/shopware_api_client/endpoints/admin/core/product.py
+++ b/src/shopware_api_client/endpoints/admin/core/product.py
@@ -70,7 +70,7 @@ class ProductBase(ApiModelBase[EndpointClass]):
     pack_unit: str | None = None
     pack_unit_plural: str | None = None
     custom_fields: dict[str, Any] | None = None
-    slot_config: dict[str, Any] | None = None
+    slot_config: dict[str, Any] | list | None = None
     custom_search_keywords: list[str] | None = None
     available_stock: int | None = Field(default=None, exclude=True)
     stock: int | None = None


### PR DESCRIPTION
According to shopware docs slotConfig is of type object or null.

Now shopware returns an empty list in some cases?
We allow it until we know what's going on.