### PR TITLE
Shopware sometime returns list for orderLineItem payload field ...

### DIFF
--- a/src/shopware_api_client/endpoints/admin/core/order_line_item.py
+++ b/src/shopware_api_client/endpoints/admin/core/order_line_item.py
@@ -23,7 +23,7 @@ class OrderLineItemBase(ApiModelBase[EndpointClass]):
     referenced_id: str | None = None
     quantity: int
     label: str
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any] | list | None = None
     good: bool | None = None
     removable: bool | None = None
     stackable: bool | None = None


### PR DESCRIPTION
"payload" is usually a dict, but in some cases (line item is discount) can be an empty list.