### PR TITLE
Fix recursion with pydantic version 2.10 and higher

### DIFF
--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -237,6 +237,9 @@ class ApiModelBase(BaseModel, Generic[EndpointClass]):
     def __getattribute__(self, name: str) -> Any:
         from .endpoints.relations import ForeignRelation, ManyRelation
 
+        if name.startswith("__pydantic"):
+            return super().__getattribute__(name)
+
         fields = super().__getattribute__("model_fields")
 
         # hack to get the actual ForeignKey-Instance


### PR DESCRIPTION
Due to changes in pydantic 2.10 our __getattribute__ method in ApiModelBase creates an infinite recursion.