### PR TITLE
fix promotion endpoint

### DIFF
--- a/src/shopware_api_client/endpoints/admin/core/promotion.py
+++ b/src/shopware_api_client/endpoints/admin/core/promotion.py
@@ -52,8 +52,8 @@ class Promotion(PromotionBase["PromotionEndpoint"], PromotionRelations):
 
 
 class PromotionEndpoint(EndpointBase[Promotion]):
-    name = "tag"
-    path = "/tag"
+    name = "promotion"
+    path = "/promotion"
     model_class = Promotion
 
 


### PR DESCRIPTION
The promotion endpoint was erroneously referencing "tag" as the url.