### PR TITLE
Update Cart.errors type to allow more flexible data structure

### DIFF
--- a/src/shopware_api_client/endpoints/store/core/cart.py
+++ b/src/shopware_api_client/endpoints/store/core/cart.py
@@ -73,7 +73,7 @@ class Cart(ApiModelBase["CartEndpoint"]):
     token: str
     price: Price
     line_items: list[LineItem]
-    errors: list[dict[str, Any]]
+    errors: list[dict[str, Any]] | dict[str, Any] | None = None
     deliveries: list[CartDelivery]
     transactions: list[dict[str, Any]]
     modified: bool


### PR DESCRIPTION
Errors sometimes returns just a dict. Making it optional, too.