### PR TITLE
Handle json decode error, better access for httpx client (public facing)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"service": "services",
 	"workspaceFolder": "/workspaces",
 	"remoteUser": "vscode",
+	"files.eol": "\n",
 	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	"postStartCommand": "bash .devcontainer/post-start.sh",
 	"customizations": {

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,1 +1,1 @@
-poetry install --no-root
+poetry install --no-root --with dev

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "python.testing.pytestArgs": [
-        "./test",
-        "--rootdir=./test",
+        "./tests",
+        "--rootdir=./tests",
         "--cov",
         "--cov-branch",
         "--cov-report=xml:./coverage.xml"

--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ We have two classes `Base` and `Relations`. This way we can [reuse the Base-Mode
 
 ## Development
 
+### Testing
+
+You can use `poetry build` and `poetry run pip install -e .` to install the current src.
+
+Then run `poetry run pytest .` to execute the tests.
+
 ### Model Creation
 
 Shopware provides API-definitions for their whole API. You can download it from `<shopurl>/api/_info/openapi3.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ python_files = ["test_*.py", "*_test.py"]
 filterwarnings = ["ignore::DeprecationWarning"]
 asyncio_mode = "auto"
 addopts = [
-    "--rootdir=./test",
+    "--rootdir=./tests",
     "--cov-branch",
     "--cov=src",
     "--cov-report=xml",

--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -1,7 +1,7 @@
 import asyncio
-from functools import cached_property
 import json
 from datetime import UTC, datetime
+from functools import cached_property
 from typing import (
     Any,
     AsyncGenerator,
@@ -10,6 +10,7 @@ from typing import (
     Self,
     Type,
     TypeVar,
+    cast,
     get_origin,
     overload,
 )
@@ -82,13 +83,13 @@ class ClientBase:
             response.content,
             response.headers,
         )
-    
+
     @cached_property
     def http_client(self) -> httpx.AsyncClient:
         return self._get_client()
 
     def _get_client(self) -> httpx.AsyncClient:
-        # FIXME: rename _get_client -> _get_http_client to avoid confusion with ApiModelBase._get_client 
+        # FIXME: rename _get_client -> _get_http_client to avoid confusion with ApiModelBase._get_client
         #        (fix middleware usage of private method usage first)
         raise NotImplementedError()
 
@@ -110,6 +111,11 @@ class ClientBase:
         client = self.http_client
         client.timeout = timeout  # type: ignore
 
+    async def retry_sleep(self, retry_wait_base: int, retry_count: int) -> None:
+        retry_sleep = retry_wait_base**retry_count
+        logger.debug(f"Try failed, retrying in {retry_sleep} seconds.")
+        await asyncio.sleep(retry_sleep)
+
     async def _make_request(self, method: str, relative_url: str, **kwargs: Any) -> httpx.Response:
         if relative_url.startswith("http://") or relative_url.startswith("https://"):
             url = relative_url
@@ -120,6 +126,7 @@ class ClientBase:
         headers = self._get_headers()
         headers.update(kwargs.pop("headers", {}))
 
+        retry_wait_base = int(kwargs.pop("retriy_wait_base", 2))
         retries = int(kwargs.pop("retries", 0))
         retry_errors = tuple(
             kwargs.pop("retry_errors", [SWAPIInternalServerError, SWAPIServiceUnavailable, SWAPIGatewayTimeout])
@@ -133,7 +140,7 @@ class ClientBase:
             try:
                 response = await client.request(method, url, headers=headers, **kwargs)
             except httpx.RequestError as exc:
-                if retry_count == retries:
+                if retry_count >= retries:
                     raise SWAPIException(f"HTTP client exception ({exc.__class__.__name__}). Details: {str(exc)}")
                 await asyncio.sleep(2**retry_count)
                 retry_count += 1
@@ -144,8 +151,8 @@ class ClientBase:
                     errors: list = response.json().get("errors")
                     # ensure `errors` attribute is a list/tuple, fallback to from_response if not
                     if not isinstance(errors, (list, tuple)):
-                       raise ValueError("`errors` attribute in json not a list/tuple!")
-                    
+                        raise ValueError("`errors` attribute in json not a list/tuple!")
+
                     error: SWAPIError | SWAPIErrorList = SWAPIError.from_errors(errors)
                 except (json.JSONDecodeError, ValueError):
                     error: SWAPIError | SWAPIErrorList = SWAPIError.from_response(response)  # type: ignore
@@ -166,26 +173,28 @@ class ClientBase:
                 if retry_count == retries:
                     raise error
 
-                logger.debug(f"Try failed, retrying in {2 ** retry_count} seconds.")
-                await asyncio.sleep(2**retry_count)
+                await self.retry_sleep(retry_wait_base, retry_count)
                 retry_count += 1
             else:
                 # guard against "200 okay" responses with malformed json
                 try:
-                    response.json_cached = response.json()
+                    setattr(response, "json_cached", response.json())
                 except json.JSONDecodeError:
                     # retries exhausted?
-                    if retry_count == retries:
-                        # promote response to http 500
+                    if retry_count >= retries:
                         response.status_code = 500
-                        exc = SWAPIError.from_response(response)
-                        # prefix details with x-trace-header to 
-                        exc.detail = f"x-trace-id: {str(response.headers.get("x-trace-id", "not-set"))}" + exc.text
-                    
+                        exception = SWAPIError.from_response(response)
+                        # prefix details with x-trace-header to
+                        exception.detail = (
+                            f"x-trace-id: {str(response.headers.get('x-trace-id', 'not-set'))}" + exception.detail
+                        )
+                        raise exception
+
                     # schedule retry
+                    await self.retry_sleep(retry_wait_base, retry_count)
                     retry_count += 1
                     continue
-                
+
                 return response
 
     async def get(self, relative_url: str, **kwargs: Any) -> httpx.Response:
@@ -396,7 +405,7 @@ class EndpointBase(Generic[ModelClass]):
         field = self.model_class.model_fields[name]
 
         if get_origin(field.annotation) in [ForeignRelation, ManyRelation]:
-            return to_camel(name)
+            return cast(str, to_camel(name))
         else:
             return self.model_class.model_fields[name].serialization_alias or name
 

--- a/src/shopware_api_client/client.py
+++ b/src/shopware_api_client/client.py
@@ -164,7 +164,10 @@ class AdminClient(ClientBase, AdminEndpoints):
 
             result = await self._retry_bulk_parts(action="delete", name=name, objs=objs, exception=e, **request_kwargs)
         else:
-            result = response.json()
+            if hasattr(response, "json_cached"):
+                result = response.json_cached
+            else:
+                result = response.json()
 
         return result
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,7 +32,7 @@ class TestAdminClient:
 
         exc: SWAPIError = exc_info.value
         assert exc.status == 500
-        assert exc.title == "Internal Server Error"
+        assert exc.title == httpx.codes.get_reason_phrase(500)
         assert "x-trace-id" in exc.headers
         assert "bla" in exc.detail
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,6 +33,7 @@ class TestAdminClient:
         exc: SWAPIError = exc_info.value
         assert exc.status == 500
         assert exc.title == "Internal Server Error"
+        assert "x-trace-id" in exc.headers
         assert "bla" in exc.detail
 
     def test_creation(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,7 +25,7 @@ class TestAdminClient:
 
     def test_get_client(self) -> None:
         client = AdminClient(config=self.admin_config)
-        httpx_client = client._get_client()
+        httpx_client = client.http_client
         assert isinstance(httpx_client, httpx.AsyncClient)
 
     def test_wrong_config(self) -> None:
@@ -33,7 +33,7 @@ class TestAdminClient:
         client = AdminClient(config=self.admin_config)
 
         with pytest.raises(SWAPIConfigException):
-            client._get_client()
+            client.http_client
 
     async def test_error_on_invalid_data_from_shopware(
         self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
@@ -64,18 +64,18 @@ class TestStoreClient:
 
     def test_get_client(self) -> None:
         client = StoreClient(config=self.store_config)
-        httpx_client = client._get_client()
+        httpx_client = client.http_client
         assert isinstance(httpx_client, httpx.AsyncClient)
 
     def test_context_token(self) -> None:
         config = StoreConfig(url="https://localhost", access_key="ACCESS_KEY", context_token="CONTEXT_TOKEN")
         client = StoreClient(config=config)
-        httpx_client = client._get_client()
+        httpx_client = client.http_client
         headers = httpx_client.headers
         assert headers.get("sw-context-token") == "CONTEXT_TOKEN"
 
     def test_context_token_not_set(self) -> None:
         client = StoreClient(config=self.store_config)
-        httpx_client = client._get_client()
+        httpx_client = client.http_client
         headers = httpx_client.headers
         assert headers.get("sw-context-token") is None


### PR DESCRIPTION
- Handle malformed http status 200 responses from Shopware.
- Added public facing `http_client` property (cached) for accessing the httpx client and avoiding unnecessary _get_client calls;
- Added FIXME as reminder for later refactor (requires one change in services repo where we use the private method)
- Minor refactor in ApiModelBase._get_endpoint to avoid redundant call
- Added missing "files.eol": "\n" for devcontainer.json
- post-start.sh fix for poetry dev deps
- README clarifications for testing

Workaround for https://github.com/shopware/shopware/issues/10267