### PR TITLE
fix(json-response): Only check response for valid JSON if it is supposed to have JSON content

### DIFF
--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -44,6 +44,8 @@ from .exceptions import (
 )
 from .logging import logger
 
+APPLICATION_JSON = "application/json"
+
 EndpointClass = TypeVar("EndpointClass", bound="EndpointBase[Any]")
 ModelClass = TypeVar("ModelClass", bound="ApiModelBase[Any]")
 
@@ -94,7 +96,7 @@ class ClientBase:
         raise NotImplementedError()
 
     def _get_headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {"Content-Type": APPLICATION_JSON, "Accept": APPLICATION_JSON}
 
         if self.language_id is not None:
             headers["sw-language-id"] = str(self.language_id)
@@ -175,7 +177,7 @@ class ClientBase:
 
                 await self.retry_sleep(retry_wait_base, retry_count)
                 retry_count += 1
-            elif response.status_code == 200 and response.headers.get("Content-Type", "").startswith("application/json"):
+            elif response.status_code == 200 and response.headers.get("Content-Type", "").startswith(APPLICATION_JSON):
                 # guard against "200 okay" responses with malformed json
                 try:
                     setattr(response, "json_cached", response.json())

--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -65,7 +65,8 @@ class ClientBase:
         self.raw = raw
 
     async def __aenter__(self) -> "Self":
-        self.http_client
+        client = self.http_client
+        assert isinstance(client, httpx.AsyncClient), "http_client must be an instance of httpx.AsyncClient"
         return self
 
     async def __aexit__(self, *args: Any) -> None:
@@ -88,11 +89,9 @@ class ClientBase:
 
     @cached_property
     def http_client(self) -> httpx.AsyncClient:
-        return self._get_client()
+        return self._get_http_client()
 
-    def _get_client(self) -> httpx.AsyncClient:
-        # FIXME: rename _get_client -> _get_http_client to avoid confusion with ApiModelBase._get_client
-        #        (fix middleware usage of private method usage first)
+    def _get_http_client(self) -> httpx.AsyncClient:
         raise NotImplementedError()
 
     def _get_headers(self) -> dict[str, str]:

--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -156,7 +156,7 @@ class ClientBase:
                         raise ValueError("`errors` attribute in json not a list/tuple!")
 
                     error: SWAPIError | SWAPIErrorList = SWAPIError.from_errors(errors)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     error: SWAPIError | SWAPIErrorList = SWAPIError.from_response(response)  # type: ignore
 
                 if isinstance(error, SWAPIErrorList) and len(error.errors) == 1:

--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -175,10 +175,11 @@ class ClientBase:
 
                 await self.retry_sleep(retry_wait_base, retry_count)
                 retry_count += 1
-            else:
+            elif response.status_code == 200 and response.headers.get("Content-Type", "").startswith("application/json"):
                 # guard against "200 okay" responses with malformed json
                 try:
                     setattr(response, "json_cached", response.json())
+                    return response
                 except json.JSONDecodeError:
                     # retries exhausted?
                     if retry_count >= retries:
@@ -193,8 +194,7 @@ class ClientBase:
                     # schedule retry
                     await self.retry_sleep(retry_wait_base, retry_count)
                     retry_count += 1
-                    continue
-
+            else:
                 return response
 
     async def get(self, relative_url: str, **kwargs: Any) -> httpx.Response:

--- a/src/shopware_api_client/client.py
+++ b/src/shopware_api_client/client.py
@@ -19,7 +19,7 @@ class AdminClient(ClientBase, AdminEndpoints):
         self._client: httpx.AsyncClient | None = None
         self.init_endpoints(self)
 
-    def _get_client(self) -> httpx.AsyncClient:
+    def _get_http_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = httpx.AsyncClient(
                 event_hooks={"request": [self.log_request], "response": [self.log_response]}
@@ -180,7 +180,7 @@ class StoreClient(ClientBase, StoreEndpoints):
         self._client: httpx.AsyncClient | None = None
         self.init_endpoints(self)
 
-    def _get_client(self) -> httpx.AsyncClient:
+    def _get_http_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = httpx.AsyncClient(
                 event_hooks={"request": [self.log_request], "response": [self.log_response]},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ class TestAdminClient:
         mocker.patch(
             "httpx.AsyncClient.request",
             AsyncMock(
-                return_value=httpx.Response(status_code=200, content="read error", headers={"x-trace-id": "bla"})
+                return_value=httpx.Response(status_code=200, content="read error", headers={"x-trace-id": "bla", "content-type": "application/json"})
             ),
         )
         client = AdminClient(config=self.admin_config)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,9 +48,12 @@ class TestAdminClient:
     def test_wrong_config(self) -> None:
         self.admin_config.client_id = None
         client = AdminClient(config=self.admin_config)
+        httpx_client = None
 
         with pytest.raises(SWAPIConfigException):
-            client.http_client
+            httpx_client = client.http_client
+        
+        assert httpx_client is None
 
     async def test_error_on_invalid_data_from_shopware(
         self, mocker: MockerFixture, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
Only check response for valid JSON if it is supposed to have content: 
- Content-Type: application/json
- Response-Status: HTTP 200  (not 204)