### PR TITLE
Avoid 429 retries and pass along requested url in error headers.

### DIFF
--- a/src/shopware_api_client/base.py
+++ b/src/shopware_api_client/base.py
@@ -147,7 +147,7 @@ class ClientBase:
                 retry_count += 1
                 continue
 
-            if response.status_code >= 400:
+            if response.status_code >= 400 and response.status_code != 429:
                 try:
                     errors: list = response.json().get("errors")
                     # ensure `errors` attribute is a list/tuple, fallback to from_response if not

--- a/src/shopware_api_client/exceptions.py
+++ b/src/shopware_api_client/exceptions.py
@@ -95,6 +95,7 @@ class SWAPIError(SWAPIException):
     @classmethod
     def from_response(cls, response: Response) -> "SWAPIError":
         exception_class = cls.get_exception_class(response.status_code)
+        response.headers.set("requested-url", response.request.url)
         return exception_class(
             status=response.status_code,
             title=response.reason_phrase,


### PR DESCRIPTION
Better 429 handling: do not retry and pass along requested shopware url in response headers which will get passed down in the base exception