### PR TITLE
fix(media-api): Thumbnail createdAt field can be null

### DIFF
--- a/src/shopware_api_client/endpoints/admin/core/media_thumbnail.py
+++ b/src/shopware_api_client/endpoints/admin/core/media_thumbnail.py
@@ -1,6 +1,7 @@
+from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import Field
+from pydantic import AwareDatetime, Field
 
 from ....base import ApiModelBase, EndpointBase, EndpointClass
 from ...base_fields import IdField
@@ -9,6 +10,7 @@ from ...relations import ForeignRelation
 
 class MediaThumbnailBase(ApiModelBase[EndpointClass]):
     _identifier = "media_thumbnail"
+    created_at: AwareDatetime | None = Field(default_factory=lambda: datetime.now(UTC), exclude=True)
 
     media_id: IdField
     width: int = Field(default=0, exclude=True)

--- a/src/shopware_api_client/endpoints/admin/core/media_thumbnail.py
+++ b/src/shopware_api_client/endpoints/admin/core/media_thumbnail.py
@@ -10,7 +10,7 @@ from ...relations import ForeignRelation
 
 class MediaThumbnailBase(ApiModelBase[EndpointClass]):
     _identifier = "media_thumbnail"
-    created_at: AwareDatetime | None = Field(default_factory=lambda: datetime.now(UTC), exclude=True)
+    created_at: AwareDatetime | None = Field(default_factory=lambda: datetime.now(UTC), exclude=True)  # type: ignore
 
     media_id: IdField
     width: int = Field(default=0, exclude=True)

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,0 +1,27 @@
+from datetime import UTC, datetime
+
+from shopware_api_client.endpoints.admin import MediaThumbnail
+
+
+class TestThumbnail:
+    def test_thumbnail_created_at_can_be_empty(self):
+        thumbnail = MediaThumbnail(
+            media_id="deadbeef123412341234123456789012",
+            width=100,
+            height=100,
+            created_at=None,
+            updated_at=None,
+        )
+        assert thumbnail.created_at is None
+        assert thumbnail.updated_at is None
+
+    def test_thumbnail_created_at_can_be_filled(self):
+        thumbnail = MediaThumbnail(
+            media_id="deadbeef123412341234123456789012",
+            width=100,
+            height=100,
+            created_at="2023-01-01T00:00:00Z",
+            updated_at=None,
+        )
+        assert thumbnail.created_at == datetime(2023, 1, 1, 0, 0, 0, tzinfo=UTC)
+        assert thumbnail.updated_at is None


### PR DESCRIPTION
When saving media as urls instead of uploading to Shopware, shopware generates thumbnail urls, but does not generate images. The createdAt field is empty on those thumbnails.

We now allow a createdAt field to be null in the MediaThumbnail schema.

Fixes https://gws-gesellschaft-fur-warenwirt.sentry.io/issues/6993262264/?project=4506943362105344&query=is%3Aunresolved&referrer=issue-stream